### PR TITLE
feat: added funcionality to delete url

### DIFF
--- a/src/documentation/swagger/index.ts
+++ b/src/documentation/swagger/index.ts
@@ -1,4 +1,5 @@
 import {
+  deleteUrlSchema,
   getShortedUrlSchema,
   searchManyUrlSchema,
   updateUrlBodySchema,
@@ -38,6 +39,11 @@ export const urlSearchManyJsonSchema = {
 export const urlUpdateJsonSchema = {
   body: zodToJsonSchema(updateUrlBodySchema),
   querystring: zodToJsonSchema(updateUrlQuerySchema),
+  tags: swaggerTagsGroups.url,
+};
+
+export const urlDeleteJsonSchema = {
+  params: zodToJsonSchema(deleteUrlSchema),
   tags: swaggerTagsGroups.url,
 };
 

--- a/src/http/controller/url.routes.ts
+++ b/src/http/controller/url.routes.ts
@@ -1,5 +1,6 @@
 import {
   urlCreateJsonSchema,
+  urlDeleteJsonSchema,
   urlGetJsonSchema,
   urlSearchManyJsonSchema,
   urlUpdateJsonSchema,
@@ -17,4 +18,5 @@ export async function urlRoutes(app: FastifyInstance) {
   // private routes
   app.get("/", { schema: urlSearchManyJsonSchema, onRequest: [app.authenticate] }, urlController.list);
   app.patch("/", { schema: urlUpdateJsonSchema, onRequest: [app.authenticate] }, urlController.update);
+  app.delete("/:urlId", { schema: urlDeleteJsonSchema, onRequest: [app.authenticate] }, urlController.delete);
 }

--- a/src/infra/db/migrations/1731472913442_add-deleted-column.ts
+++ b/src/infra/db/migrations/1731472913442_add-deleted-column.ts
@@ -1,0 +1,10 @@
+import type { Kysely } from "kysely";
+import type { DB } from "../types/db";
+
+export async function up(db: Kysely<DB>): Promise<void> {
+  await db.schema.alterTable("url").addColumn("deletedAt", "timestamp").execute();
+}
+
+export async function down(db: Kysely<DB>): Promise<void> {
+  await db.schema.alterTable("url").dropColumn("deletedAt").execute();
+}

--- a/src/infra/db/types/db.d.ts
+++ b/src/infra/db/types/db.d.ts
@@ -14,6 +14,7 @@ export type Timestamp = ColumnType<Date, Date | string, Date | string>;
 export interface Url {
   clicks: Generated<number>;
   createdAt: Generated<Timestamp>;
+  deletedAt: Timestamp | null;
   id: Generated<string>;
   origUrl: string;
   shortUrl: string;

--- a/src/repositories/in-memory/url-repository-in-memory.ts
+++ b/src/repositories/in-memory/url-repository-in-memory.ts
@@ -21,6 +21,7 @@ export class UrlRepositoryInMemory implements UrlRepository {
   async create(data: CreateUrlParams): Promise<Selectable<Url> | undefined> {
     const createdUrl: Selectable<Url> = {
       ...data,
+      deletedAt: null,
       createdAt: new Date(),
       updatedAt: new Date(),
       id: randomUUID(),
@@ -47,6 +48,10 @@ export class UrlRepositoryInMemory implements UrlRepository {
 
       if (data.origUrl) {
         urlToUpdate.origUrl = data.origUrl;
+      }
+
+      if (data.deletedAt) {
+        urlToUpdate.deletedAt = data.deletedAt;
       }
 
       urlToUpdate.updatedAt = new Date();

--- a/src/repositories/kysely/url-repository-kysely.ts
+++ b/src/repositories/kysely/url-repository-kysely.ts
@@ -14,6 +14,7 @@ export class UrlRepositoryKysely implements UrlRepository {
     const url = await db
       .selectFrom("url")
       .where((eb) => eb("url.urlId", "=", data.urlId ?? "").or("url.origUrl", "=", data.origUrl ?? ""))
+      .where("deletedAt", "is", null)
       .selectAll()
       .executeTakeFirst();
 
@@ -26,7 +27,7 @@ export class UrlRepositoryKysely implements UrlRepository {
   }
 
   async updateOne(data: UpdateOneParams): Promise<void> {
-    let query = db.updateTable("url").where("url.urlId", "=", data.urlId);
+    let query = db.updateTable("url").where("url.urlId", "=", data.urlId).where("deletedAt", "is", null);
 
     if (data.userId) {
       query = query.where("url.userId", "=", data.userId);
@@ -44,6 +45,12 @@ export class UrlRepositoryKysely implements UrlRepository {
       });
     }
 
+    if (data.deletedAt) {
+      query = query.set({
+        deletedAt: data.deletedAt,
+      });
+    }
+
     await query.execute();
   }
 
@@ -52,6 +59,7 @@ export class UrlRepositoryKysely implements UrlRepository {
       .selectFrom("url")
       .selectAll()
       .where("userId", "=", data.userId)
+      .where("deletedAt", "is", null)
       .orderBy("clicks", data.order)
       .limit(data.perPage)
       .offset((data.page - 1) * data.perPage);

--- a/src/repositories/url-repository.ts
+++ b/src/repositories/url-repository.ts
@@ -6,7 +6,7 @@ export interface FindOneUrlParams {
   urlId?: string;
 }
 
-export interface CreateUrlParams extends Omit<Selectable<Url>, "createdAt" | "updatedAt" | "id"> {}
+export interface CreateUrlParams extends Omit<Selectable<Url>, "createdAt" | "updatedAt" | "id" | "deletedAt"> {}
 
 export interface SearchManyParams {
   query?: string;
@@ -21,6 +21,7 @@ export interface UpdateOneParams {
   userId?: string;
   origUrl?: string;
   incClick?: number;
+  deletedAt?: Date;
 }
 
 export interface UrlRepository {

--- a/src/schemas/url.ts
+++ b/src/schemas/url.ts
@@ -35,6 +35,12 @@ export const updateUrlQuerySchema = z.object({
   }),
 });
 
+export const deleteUrlSchema = z.object({
+  urlId: z.string({
+    required_error: "urlId is required",
+  }),
+});
+
 // CREATE
 export type CreateUrlInput = z.infer<typeof urlCreateSchema>;
 
@@ -45,5 +51,8 @@ export type GetShortedUrlInput = z.infer<typeof getShortedUrlSchema>;
 export type SearchManyUrlsInput = z.infer<typeof searchManyUrlSchema>;
 
 // Update
-export type updateUrlBodyInput = z.infer<typeof updateUrlBodySchema>;
-export type updateUrlQueryInput = z.infer<typeof updateUrlQuerySchema>;
+export type UpdateUrlBodyInput = z.infer<typeof updateUrlBodySchema>;
+export type UpdateUrlQueryInput = z.infer<typeof updateUrlQuerySchema>;
+
+// Delete
+export type DeleteUrlInput = z.infer<typeof deleteUrlSchema>;

--- a/src/use-cases/delete-url/index.test.ts
+++ b/src/use-cases/delete-url/index.test.ts
@@ -4,15 +4,15 @@ import { UserRepositoryInMemory } from "@/repositories/in-memory/user-repository
 import type { UserRepository } from "@/repositories/user-repository";
 import bcrypt from "bcrypt";
 import type { Selectable } from "kysely";
-import { beforeEach, describe, expect, it } from "vitest";
-import { UpdateUrlUseCase } from ".";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { DeleteUrlUseCase } from ".";
 import { ShortenerUrlUseCase } from "../shortener-url";
 
-describe("UpdateUrl use case", () => {
+describe("DeleteUrl use case", () => {
   let urlRepository: UrlRepositoryInMemory;
   let userRepository: UserRepository;
   let shortenerUrlUseCase: ShortenerUrlUseCase;
-  let sut: UpdateUrlUseCase;
+  let sut: DeleteUrlUseCase;
   let url: Selectable<Url> | undefined;
   let user: Selectable<User> | undefined;
 
@@ -22,7 +22,7 @@ describe("UpdateUrl use case", () => {
     urlRepository = new UrlRepositoryInMemory();
     userRepository = new UserRepositoryInMemory();
     shortenerUrlUseCase = new ShortenerUrlUseCase(urlRepository, userRepository);
-    sut = new UpdateUrlUseCase(urlRepository, userRepository);
+    sut = new DeleteUrlUseCase(urlRepository, userRepository);
 
     user = await userRepository.create({
       email: "teste@teste.com",
@@ -34,16 +34,21 @@ describe("UpdateUrl use case", () => {
       origUrl,
       userId: user?.id ?? "",
     });
+
+    vi.useFakeTimers();
   });
 
-  it("should be can UPDATE origUrl", async () => {
-    const updatedUrl = "youtube.com.br";
+  it("deletedAt return NULL by default", async () => {
+    expect(url?.deletedAt).toBeNull();
+  });
+
+  it("Should be can set deletedAt", async () => {
+    const date = new Date();
     await sut.execute({
-      origUrl: updatedUrl,
       urlId: url?.urlId ?? "",
       userId: user?.id ?? "",
     });
 
-    expect(url?.origUrl).toEqual(updatedUrl);
+    expect(url?.deletedAt).toEqual(date);
   });
 });

--- a/src/use-cases/delete-url/index.ts
+++ b/src/use-cases/delete-url/index.ts
@@ -1,0 +1,31 @@
+import type { UrlRepository } from "@/repositories/url-repository";
+import type { UserRepository } from "@/repositories/user-repository";
+import { ResourceNotFoundError } from "../errors/resource-not-found";
+
+interface DeleteUrlUseCaseParams {
+  userId: string;
+  urlId: string;
+}
+
+export class DeleteUrlUseCase {
+  constructor(
+    private urlRepository: UrlRepository,
+    private userRepository: UserRepository,
+  ) {}
+
+  async execute(data: DeleteUrlUseCaseParams) {
+    const user = await this.userRepository.findOne({ id: data.userId });
+
+    if (!user) {
+      throw new ResourceNotFoundError("User");
+    }
+
+    const url = await this.urlRepository.findOne({ urlId: data.urlId });
+
+    if (!url) {
+      throw new ResourceNotFoundError("Url");
+    }
+
+    await this.urlRepository.updateOne({ deletedAt: new Date(), urlId: data.urlId, userId: user.id });
+  }
+}

--- a/src/use-cases/factories/make-delete-url-factory.ts
+++ b/src/use-cases/factories/make-delete-url-factory.ts
@@ -1,0 +1,11 @@
+import { UrlRepositoryKysely } from "@/repositories/kysely/url-repository-kysely";
+import { UserRepositoryKysely } from "@/repositories/kysely/user-repository-kysely";
+import { DeleteUrlUseCase } from "../delete-url";
+
+export function makeDeleteUrlFactory() {
+  const urlRepository = new UrlRepositoryKysely();
+  const userRepository = new UserRepositoryKysely();
+  const deleteUrlUseCase = new DeleteUrlUseCase(urlRepository, userRepository);
+
+  return deleteUrlUseCase;
+}


### PR DESCRIPTION
--> GERADO PELO COPILOT

Este pull request introduz uma nova funcionalidade para lidar com a exclusão de URLs e inclui várias mudanças relacionadas em diversos arquivos. As alterações mais importantes incluem a adição de um novo esquema para a exclusão de URLs, a atualização do controlador de URLs para lidar com solicitações de exclusão, a modificação das classes de repositório para suportar a exclusão suave e a adição de testes para a nova funcionalidade de exclusão.

### Nova Funcionalidade: Exclusão de URLs

* [`src/documentation/swagger/index.ts`](diffhunk://#diff-67f117dae4ab662f33aa0a5430f174d1454ad4e9086fe3d2bd8ca35759d47a4aR2): Adicionou `deleteUrlSchema` e `urlDeleteJsonSchema` para a exclusão de URLs.
* [`src/http/controller/url.routes.ts`](diffhunk://#diff-e84714f0a259f7fb43a2f79ab430c8ff10aed0dfa4c1f61a05a28a1fd1a6b620R3): Atualizou as rotas para incluir um novo endpoint DELETE para URLs.
* [`src/http/controller/url.ts`](diffhunk://#diff-264ef221df69bdd4687f47377f68a25e7e872d8e9c40d8bcd795495e8f064526R4-R11): Adicionou um novo método `delete` na classe `UrlController` para lidar com a lógica de exclusão de URLs.
* [`src/schemas/url.ts`](diffhunk://#diff-4bb55b1f721a36d3ecc8e3e4a6706e3a26971a38593c11971d2532863247ebf8R38-R43): Definiu `deleteUrlSchema` e adicionou o tipo `DeleteUrlInput`.

### Atualizações no Repositório

* [`src/infra/db/migrations/1731472913442_add-deleted-column.ts`](diffhunk://#diff-95983320f8e17d9e40c5e8467c3e2900ac869fe7c9a3b8f72c30e28b681c31e8R1-R10): Adicionou uma migração para incluir a coluna `deletedAt` na tabela `url` para a exclusão suave.
* [`src/repositories/in-memory/url-repository-in-memory.ts`](diffhunk://#diff-e8b4be4e2628d9104de6522423f22361c954cb434a1a9d44a225b0645cdf5740R24): Atualizou o repositório em memória para lidar com o campo `deletedAt`.
* [`src/repositories/kysely/url-repository-kysely.ts`](diffhunk://#diff-7fd0a0448bfb106742d2fd04efa89d31668865124cc03c335fb6e89a6ae00d6fR17): Modificou o repositório Kysely para suportar exclusão suave, verificando o campo `deletedAt` nas consultas.
* [`src/repositories/url-repository.ts`](diffhunk://#diff-1a710450742412947ba801eb840117d24cbb59309f20a5a28fbcd4382656e1faL9-R9): Atualizou as interfaces de repositório para incluir `deletedAt` em `UpdateOneParams` e excluí-lo de `CreateUrlParams`.

### Testes

* [`src/use-cases/delete-url/index.test.ts`](diffhunk://#diff-5bb45f50ef741bb43197306cf37980f47d845e7ba2b0221871690212dbfd28f7R1-R54): Adicionou testes para o `DeleteUrlUseCase` para garantir que as URLs possam ser marcadas como excluídas.
* [`src/use-cases/update-url/index.test.ts`](diffhunk://#diff-b6ade26acae84e32cbcf1abc810fdf8f86e12b991b271d875d59a74edc6ad37eL11-R11): Corrigiu descrições de testes para refletir com precisão a funcionalidade testada.

### Casos de Uso e Factories

* [`src/use-cases/delete-url/index.ts`](diffhunk://#diff-ae3e6901c074c327afe9d9d5f00ad2248f87439c7765e5c3a2e17b8d0df36677R1-R31): Implementou o `DeleteUrlUseCase` para lidar com a lógica de exclusão.
* [`src/use-cases/factories/make-delete-url-factory.ts`](diffhunk://#diff-c6a8e732a025d9b1d30f3c32f9fbe0a9c3a1cdfe75a9bc047c1eb16e2a478e70R1-R11): Criou uma função de factory para instanciar o `DeleteUrlUseCase`.