### PR TITLE
refactor: add transactions on create url

### DIFF
--- a/src/repositories/kysely/url-repository-kysely.ts
+++ b/src/repositories/kysely/url-repository-kysely.ts
@@ -21,7 +21,9 @@ export class UrlRepositoryKysely implements UrlRepository {
     return url;
   }
   async create(data: CreateUrlParams): Promise<Selectable<Url> | undefined> {
-    const url = await db.insertInto("url").values(data).returningAll().executeTakeFirst();
+    const url = await db.transaction().execute(async (trx) => {
+      return trx.insertInto("url").values(data).returningAll().executeTakeFirst();
+    });
 
     return url;
   }


### PR DESCRIPTION
This pull request includes a change to the `UrlRepositoryKysely` class in the `src/repositories/kysely/url-repository-kysely.ts` file to ensure that URL creation operations are executed within a transaction.

Changes to `UrlRepositoryKysely` class:

* Modified the `create` method to wrap the insertion of a new URL into a transaction, ensuring atomicity and consistency of the operation.